### PR TITLE
Cambio en el movimiento

### DIFF
--- a/Snake.c
+++ b/Snake.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 volatile unsigned int *led_base = (unsigned int *)LED_MATRIX_0_BASE;
 volatile unsigned int *d_pad_up = (unsigned int *)D_PAD_0_UP;
 volatile unsigned int *d_pad_do = (unsigned int *)D_PAD_0_DOWN;
@@ -45,14 +44,14 @@ void updateSnake(int x, int y) {
 }
 
 void main() {
-    int x = 1, y = 0;  
+    int x = 2, y = 0;  
     startGame();
     
     while (1) {
-        if (*d_pad_up && y == 0) { x = 0; y = -1; }  
-        else if (*d_pad_do && y == 0) { x = 0; y = 1; } 
-        else if (*d_pad_le && x == 0) { x = -1; y = 0; } 
-        else if (*d_pad_ri && x == 0) { x = 1; y = 0; }  
+        if (*d_pad_up && y == 0) { x = 0; y = -2; }  
+        else if (*d_pad_do && y == 0) { x = 0; y = 2; } 
+        else if (*d_pad_le && x == 0) { x = -2; y = 0; } 
+        else if (*d_pad_ri && x == 0) { x = 2; y = 0; }  
 
         updateSnake(x, y);
         createSnake();


### PR DESCRIPTION
Se cambia el movimiento para que no se mueva de un LED a otro, sino de dos en dos (para evitar problemas al comer la manzana y por funcionalidad en general).